### PR TITLE
Add setters for the value of each widget's State struct.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@
 //! This crate assumes you know the basics of how to use [`Iced`]. If you
 //! haven't alreay, please check it out [`here`].
 //!
-//! ```
+//! ```no_run
 // Import iced modules.
 //! use iced::{
 //!     Align, Column, Container, Element, Length, Sandbox, Settings, Text,

--- a/src/native/h_slider.rs
+++ b/src/native/h_slider.rs
@@ -219,6 +219,12 @@ impl State {
         }
     }
 
+    /// Set the `normal_param.value` of the [`HSlider`].
+    pub fn set(&mut self, normal: Normal) {
+        self.normal_param.value = normal;
+        self.continuous_normal = normal.into();
+    }
+
     /// Is the [`HSlider`] currently in the dragging state?
     ///
     /// [`HSlider`]: struct.HSlider.html

--- a/src/native/knob.rs
+++ b/src/native/knob.rs
@@ -204,6 +204,12 @@ impl State {
         }
     }
 
+    /// Set the value of the knob.
+    pub fn set(&mut self, normal: Normal) {
+        self.normal_param.value = normal;
+        self.continuous_normal = normal.into();
+    }
+
     /// Is the [`Knob`] currently in the dragging state?
     ///
     /// [`Knob`]: struct.Knob.html

--- a/src/native/knob.rs
+++ b/src/native/knob.rs
@@ -204,7 +204,7 @@ impl State {
         }
     }
 
-    /// Set the value of the knob.
+    /// Set the `normal_param.value` of the [`Knob`].
     pub fn set(&mut self, normal: Normal) {
         self.normal_param.value = normal;
         self.continuous_normal = normal.into();

--- a/src/native/mod_range_input.rs
+++ b/src/native/mod_range_input.rs
@@ -151,6 +151,12 @@ impl State {
         }
     }
 
+    /// Set the `normal_param.value` of the [`ModRangeInput`].
+    pub fn set(&mut self, normal: Normal) {
+        self.normal_param.value = normal;
+        self.continuous_normal = normal.into();
+    }
+
     /// Is the [`ModRangeInput`] currently in the dragging state?
     ///
     /// [`ModRangeInput`]: struct.ModRangeInput.html

--- a/src/native/ramp.rs
+++ b/src/native/ramp.rs
@@ -192,6 +192,12 @@ impl State {
         }
     }
 
+    /// Set the `normal_param.value` of the [`Ramp`].
+    pub fn set(&mut self, normal: Normal) {
+        self.normal_param.value = normal;
+        self.continuous_normal = normal.into();
+    }
+
     /// Is the [`Ramp`] currently in the dragging state?
     ///
     /// [`Ramp`]: struct.Ramp.html

--- a/src/native/v_slider.rs
+++ b/src/native/v_slider.rs
@@ -216,6 +216,12 @@ impl State {
         }
     }
 
+    /// Set the `normal_param.value` of the [`VSlider`].
+    pub fn set(&mut self, normal: Normal) {
+        self.normal_param.value = normal;
+        self.continuous_normal = normal.into();
+    }
+
     /// Is the [`VSlider`] currently in the dragging state?
     ///
     /// [`VSlider`]: struct.VSlider.html

--- a/src/native/xy_pad.rs
+++ b/src/native/xy_pad.rs
@@ -149,6 +149,18 @@ impl State {
         }
     }
 
+    /// Set the `normal_param_x.value` of the [`XYPad`].
+    pub fn set_x(&mut self, normal: Normal) {
+        self.normal_param_x.value = normal;
+        self.continuous_normal_x = normal.into();
+    }
+
+    /// Set the `normal_param_y.value` of the [`XYPad`].
+    pub fn set_y(&mut self, normal: Normal) {
+        self.normal_param_y.value = normal;
+        self.continuous_normal_y = normal.into();
+    }
+
     /// Is the [`XYPad`] currently in the dragging state?
     ///
     /// [`XYPad`]: struct.XYPad.html


### PR DESCRIPTION
In all of the widgets' `State` struct, there is the public field `normal_param`. Normally, one could just set and get values from `normal_param` since it is public, but a second, private field called `continuous_normal` ends up overwriting `normal_param` on every `on_event` call. This means it's not possible to actually set `normal_param.value` and have it stay set, which is undesirable since it results in the following bug:

1. A user turns the knob widget.
2. The knob value is then altered manually (for example, this might happen if a VST host modifies a parameter, and the knob happens to be connected to that parameter)
3. The user then interacts with the knob widget.
4. Due to `continuous_normal` overwriting `normal_param`, the knob's value is now reset to the value in step 1, causing an undesirable "snap" or "jump" in the knob's value!

To fix this, this PR adds a setter for each widget that sets both `normal_param` and `continuous_normal`. In the future, `normal_param` should probably be made private and a getter be exposed instead.

This PR also adds `no_run` to the example in the documentation since the example isn't actually a test and also if it runs, it will cause `cargo test` to hang, since iced doesn't return.

This fixes #7.